### PR TITLE
bugfix: only generate nicknames on registration

### DIFF
--- a/routes/index.ts
+++ b/routes/index.ts
@@ -64,15 +64,15 @@ router.post(
       ).map(record => record.nickname);
 
       let nickname = base;
-      while (candidates.includes(nickname)) {
-        const randomString = cryptoRandomString({
-          length: 4,
-          type: 'distinguishable'
-        }).toLowerCase();
-        nickname = `${base}-${randomString}`;
-      }
-
       if (!exists) {
+        while (candidates.includes(nickname)) {
+          const randomString = cryptoRandomString({
+            length: 4,
+            type: 'distinguishable'
+          }).toLowerCase();
+          nickname = `${base}-${randomString}`;
+        }
+
         const defaults = {
           score: 0,
           is_admin: false,


### PR DESCRIPTION
This PR fixes the login callback endpoint to only generate nicknames for new users